### PR TITLE
Changes for installing and testing for MacOS

### DIFF
--- a/Tests/cpp/Makefile_MODEL
+++ b/Tests/cpp/Makefile_MODEL
@@ -21,7 +21,8 @@ unittests: $(PTOOLS_TEST_BIN)
 	./$^
 
 $(PTOOLS_TEST_BIN): $(PTOOLS_TEST_SRC)
-	g++ -O2 -I. -I../../headers -o $@ $< $(LIBPTOOLS) -l$(LIBPYTHON) 
+	#g++ -O2 -I. -I../../headers -o $@ $< $(LIBPTOOLS) -l$(LIBPYTHON) 
+	CPP_COMPILE_STRING
 
 $(PTOOLS_TEST_SRC): ptoolstest.h
 	python cxxtestgen.py --error-printer $< > $@

--- a/setup.py
+++ b/setup.py
@@ -433,7 +433,7 @@ def setup_cpp_tests():
             cpp_compile_string = "g++ -O2 -I. -I../../headers -I%s -o $@ $< $(LIBPTOOLS) -l$(LIBPYTHON)" % boost_dir
         # Hack to get around stripping of relative path info ../../ from dylab path in output file ptoolstest.bin
         try:
-            p = subprocess.Popen(["ln", "-s", "../../build"]).wait()
+            p = subprocess.Popen(["ln", "-s", "../../build"], cwd="Tests/cpp/").wait()
         except:
             print("Warning: Unable to make symbolic link from Tests/cpp/build to build, skipping...")
     else:

--- a/setup.py
+++ b/setup.py
@@ -431,11 +431,16 @@ def setup_cpp_tests():
         else:
             # Other macs same as linux case
             cpp_compile_string = "g++ -O2 -I. -I../../headers -I%s -o $@ $< $(LIBPTOOLS) -l$(LIBPYTHON)" % boost_dir
+        # Hack to get around stripping of relative path info ../../ from dylab path in output file ptoolstest.bin
+        try:
+            p = subprocess.Popen(["ln", "-s", "../../build"]).wait()
+        except:
+            print("Warning: Unable to make symbolic link from Tests/cpp/build to build, skipping...")
     else:
         cpp_compile_string = "g++ -O2 -I. -I../../headers -I%s -o $@ $< $(LIBPTOOLS) -l$(LIBPYTHON)" % boost_dir
 
     lines = open('Tests/cpp/Makefile_MODEL','r').readlines()
-    newlines = [ string.replace(l,'CPP_COMPILE_STRING',cpp_compile_string) for l in lines ]	   
+    newlines = [ string.replace(line, 'CPP_COMPILE_STRING', cpp_compile_string) for line in lines ]	   
     open("Tests/cpp/Makefile",'w').writelines(newlines)
 
 


### PR DESCRIPTION
Fixes issues #66, #67, #68 and #70.
Fixes issue #69  (although I hadn't observed this when making the commit 1543fbd)

New in setup.py
- specifies `os.environ['CXX'] = 'clang++'` and `os.environ['CC'] = 'clang'` for darwin (macos)
- addresses darwin "bundle" versus "dynamiclib" distinction when creating `_ptools.so`
- adds new function `setup_cpp_tests()`

The new function `setup_cpp_tests()` does two things:
- writes `Tests/cpp/Makefile` (using new file `Tests/cpp/Makefile_MODEL` as template) with compile string for `ptoolstest.bin` that includes boost libraries
- for darwin, adds symlink to build directory so ptoolstest.bin can find `_ptools.so`

Builds and passes all tests on a new Sierra install (10.12.1).
Builds and passes all tests on Yosemite (10.10.5).
Builds and passes all tests (`make test`) in docker interactive container `ptools_interactive`.